### PR TITLE
change dep versions from wildcard to semvar compat

### DIFF
--- a/socks5-proto/Cargo.toml
+++ b/socks5-proto/Cargo.toml
@@ -11,6 +11,6 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/EAimTY/socks5-server"
 
 [dependencies]
-byteorder = "1.4.*"
-bytes = "1.2.*"
-tokio = { version = "1.20.*", features = ["io-util"] }
+byteorder = "1.4"
+bytes = "1.2"
+tokio = { version = "1.20", features = ["io-util"] }

--- a/socks5-server/Cargo.toml
+++ b/socks5-server/Cargo.toml
@@ -11,10 +11,10 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/EAimTY/socks5-server"
 
 [dependencies]
-async-trait = "0.1.*"
-bytes = "1.2.*"
-socks5-proto = "0.3.*"
-tokio = { version = "1.20.*", features = ["net"] }
+async-trait = "0.1"
+bytes = "1.2"
+socks5-proto = "0.3"
+tokio = { version = "1.20", features = ["net"] }
 
 [dev-dependencies]
-tokio = { version = "1.20.*", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.20", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
I have a project which depends on tokio 1.23.0, but the wildcards in socks5-server and socks5-proto's Cargo.toml forces using tokio 1.20.x.  This changes the deps to use semantic versioning as detailed in https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html , which allows for tokio version 1.x, where x >= 20.