### PR TITLE
add `into_split` to `Connect<Ready>`

### DIFF
--- a/socks5-server/Cargo.toml
+++ b/socks5-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socks5-server"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["EAimTY <ea.imty@gmail.com>"]
 description = "Relatively low-level asynchronized SOCKS5 server implementation based on tokio"
 categories = ["network-programming", "asynchronous"]

--- a/socks5-server/src/connection/connect.rs
+++ b/socks5-server/src/connection/connect.rs
@@ -8,7 +8,7 @@ use std::{
 use tokio::{
     io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf},
     net::{
-        tcp::{ReadHalf, WriteHalf},
+        tcp::{OwnedReadHalf, OwnedWriteHalf, ReadHalf, WriteHalf},
         TcpStream,
     },
 };
@@ -85,10 +85,16 @@ impl Connect<Ready> {
         self.stream.peer_addr()
     }
 
-    /// Returns the read half of the stream.
+    /// Returns the read/write half of the stream.
     #[inline]
     pub fn split(&mut self) -> (ReadHalf, WriteHalf) {
         self.stream.split()
+    }
+
+    /// Returns the owned read/write half of the stream.
+    #[inline]
+    pub fn into_split(self) -> (OwnedReadHalf, OwnedWriteHalf) {
+        self.stream.into_split()
     }
 
     /// Shutdown the TCP stream.


### PR DESCRIPTION
this small merge request exposes `TcpStream::into_stream` which returns an owned version of `Read/Write Half`. useful when working with threads.