### PR TITLE
Allow Auth to return data from handshake

### DIFF
--- a/socks5-server/examples/simple_socks5.rs
+++ b/socks5-server/examples/simple_socks5.rs
@@ -19,21 +19,21 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn handle(conn: IncomingConnection) -> Result<()> {
+async fn handle(conn: IncomingConnection<()>) -> Result<()> {
     match conn.handshake().await? {
-        Connection::Associate(associate, _) => {
+        Connection::Associate(associate, _, _) => {
             let mut conn = associate
                 .reply(Reply::CommandNotSupported, Address::unspecified())
                 .await?;
             conn.shutdown().await?;
         }
-        Connection::Bind(bind, _) => {
+        Connection::Bind(bind, _, _) => {
             let mut conn = bind
                 .reply(Reply::CommandNotSupported, Address::unspecified())
                 .await?;
             conn.shutdown().await?;
         }
-        Connection::Connect(connect, addr) => {
+        Connection::Connect(connect, addr, _) => {
             let target = match addr {
                 Address::DomainAddress(domain, port) => TcpStream::connect((domain, port)).await,
                 Address::SocketAddress(addr) => TcpStream::connect(addr).await,

--- a/socks5-server/src/auth.rs
+++ b/socks5-server/src/auth.rs
@@ -24,20 +24,23 @@ use tokio::net::TcpStream;
 ///
 /// #[async_trait]
 /// impl Auth for MyAuth {
+///     type Output = usize;
+///
 ///     fn as_handshake_method(&self) -> HandshakeMethod {
 ///         HandshakeMethod(0x80)
 ///     }
 ///
-///     async fn execute(&self, stream: &mut TcpStream) -> Result<()> {
+///     async fn execute(&self, stream: &mut TcpStream) -> Result<usize> {
 ///         // do something
-///         Ok(())
+///         Ok(123)
 ///     }
 /// }
 /// ```
 #[async_trait]
 pub trait Auth {
+    type Output;
     fn as_handshake_method(&self) -> HandshakeMethod;
-    async fn execute(&self, stream: &mut TcpStream) -> Result<()>;
+    async fn execute(&self, stream: &mut TcpStream) -> Result<Self::Output>;
 }
 
 /// No authentication as the socks5 handshake method.
@@ -51,6 +54,8 @@ impl NoAuth {
 
 #[async_trait]
 impl Auth for NoAuth {
+    type Output = ();
+
     fn as_handshake_method(&self) -> HandshakeMethod {
         HandshakeMethod::None
     }
@@ -80,6 +85,8 @@ impl Password {
 
 #[async_trait]
 impl Auth for Password {
+    type Output = ();
+
     fn as_handshake_method(&self) -> HandshakeMethod {
         HandshakeMethod::Password
     }


### PR DESCRIPTION
Based on the username used to authenticate with, I would like to limit the hosts that the proxy is allowed to connect to.

This PR enables that.