### PR TITLE
Re-export socks5_proto

### DIFF
--- a/socks5-server/examples/simple_socks5.rs
+++ b/socks5-server/examples/simple_socks5.rs
@@ -1,6 +1,8 @@
-use socks5_proto::{Address, Error, Reply};
 use socks5_server::{
-    auth::NoAuth, connection::state::NeedAuthenticate, Command, IncomingConnection, Server,
+    auth::NoAuth,
+    connection::state::NeedAuthenticate,
+    proto::{Address, Error, Reply},
+    Command, IncomingConnection, Server,
 };
 use std::{io::Error as IoError, sync::Arc};
 use tokio::{

--- a/socks5-server/src/lib.rs
+++ b/socks5-server/src/lib.rs
@@ -22,6 +22,8 @@ pub use crate::{
     },
 };
 
+pub use socks5_proto as proto;
+
 pub(crate) type AuthAdaptor<A> = Arc<dyn Auth<Output = A> + Send + Sync>;
 
 type ServerAcceptResult<A> = Result<


### PR DESCRIPTION
Re-export `socks5_proto` from `socks5_server` crate.  
More friendly to use like the simple_socks5 example, user can just add `socks5_server` dependency.