### PR TITLE
Reduce MSRV

### DIFF
--- a/socks5-proto/src/address.rs
+++ b/socks5-proto/src/address.rs
@@ -94,7 +94,7 @@ impl Address {
         }
     }
 
-    pub const fn unspecified() -> Self {
+    pub fn unspecified() -> Self {
         Address::SocketAddress(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0))
     }
 


### PR DESCRIPTION
I would like to use this in a project that can't use a newer Rust version than 1.67.1.

As this is only a small change, I think it is acceptable.